### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,15 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Get token
         id: get_token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58 # v1
         with:
           private_key: ${{ secrets.PRIVATE_KEY }}
           app_id: ${{ secrets.RENOVATE_APP_ID }}
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v39.0.1
+        uses: renovatebot/github-action@23a02fe7be9e93f857a953cc8162e57d2c8401ef # v39.0.1
         with:
           configurationFile: .github/renovate.json
           token: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
## Summary

Pins the actions in `.github/workflows/renovate.yaml` to full 40-character commit SHAs, addressing a supply-chain finding from automated security review (third-party actions referenced by mutable tags).

Mutable tags (`@v1`, `@v39.0.1`) can be repointed by the action's maintainer or an attacker who compromises the upstream repo. Because this workflow grants the actions access to `secrets.PRIVATE_KEY` and `secrets.RENOVATE_APP_ID` (a GitHub App private key), a malicious tag update could exfiltrate those credentials. Pinning to an immutable commit SHA removes that risk while keeping a human-readable version comment.

## Changes

| Action | Pinned SHA | Comment |
|---|---|---|
| `actions/checkout` | `c85c95e3d7251135ab7dc9ce3241c5835cc595a9` | v3.5.3 |
| `tibdex/github-app-token` | `32691ba7c9e7063bd457bd8f2a5703138591fa58` | v1 |
| `renovatebot/github-action` | `23a02fe7be9e93f857a953cc8162e57d2c8401ef` | v39.0.1 |

SHAs were resolved from each action's published tag (annotated tags dereferenced to the underlying commit). No version behavior changes — same releases, immutable references.

## Follow-up

Renovate can keep these SHAs current automatically via the [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) preset in `.github/renovate.json` — recommended so pinning doesn't mean staleness.

## Test plan

- [ ] Trigger the `Renovate` workflow (`workflow_dispatch`) and confirm it still authenticates and runs.