### PR TITLE
build: replace Dockerfile with Bazel-native rules_oci image

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 # gazelle:prefix github.com/kchygoe/gcsproxy
 gazelle(name = "gazelle")
@@ -33,4 +35,41 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":lib"],
     deps = ["@com_github_fsouza_fake_gcs_server//fakestorage"],
+)
+
+# Container image — Bazel-native replacement for the old Dockerfile.
+# Static linux/amd64 binary on distroless/static (see MODULE.bazel oci.pull).
+go_binary(
+    name = "gcsproxy_linux_amd64",
+    embed = [":lib"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "gcsproxy_layer",
+    srcs = [":gcsproxy_linux_amd64"],
+    remap_paths = {"/gcsproxy_linux_amd64": "/gcsproxy"},
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_static_linux_amd64",
+    cmd = [
+        "-b",
+        "0.0.0.0:80",
+    ],
+    entrypoint = ["/gcsproxy"],
+    tars = [":gcsproxy_layer"],
+    visibility = ["//visibility:public"],
+)
+
+# Load the image into a local Docker daemon: bazel run //:load
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["gcsproxy:latest"],
+    visibility = ["//visibility:public"],
 )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,17 @@ bazel run //:gcsproxy
 # Tests (table-driven, backed by fsouza/fake-gcs-server)
 go test -race -cover ./...
 bazel test //:gcsproxy_test
+
+# Container image (rules_oci — replaces the old Dockerfile)
+bazel build //:image          # OCI image: static linux/amd64 on distroless/static
+bazel run //:load             # load into local Docker as gcsproxy:latest
 ```
+
+The image is built entirely by Bazel via `rules_oci` + `rules_pkg` — there is no Dockerfile. `//:gcsproxy_linux_amd64` is the cross-compiled static binary (`pure = "on"`), packaged into a layer at `/gcsproxy` and assembled onto `gcr.io/distroless/static-debian13` (pinned by digest in `MODULE.bazel`; entrypoint `/gcsproxy`, default CMD `-b 0.0.0.0:80`).
 
 Runtime flags: `-b` bind address (default `127.0.0.1:8080`), `-c` GCP keyfile path (falls back to Application Default Credentials), `-v` access logging, `-bucket` fixed bucket (disables path-based bucket extraction), `-i` default index file, `-walk-up-index`, `-spa` SPA fallback, `-not-found` custom 404 object, `-cors-origin`, `-content-length`, `-log-format` (text|json), `-log-level` (debug|info|warn|error).
 
-There is **no Makefile**. Tests live in `main_test.go` (`go test ./...`).
+There is **no Makefile** and **no Dockerfile**. Tests live in `main_test.go` (`go test ./...`); the container image is the `//:image` Bazel target.
 
 ## Bazel dependency management
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.21 as build
-RUN mkdir -p /go/src/gcsproxy && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-ADD *.go Gopkg.* /go/src/gcsproxy/
-RUN cd /go/src/gcsproxy && dep ensure -v -vendor-only && CGO_ENABLED=0 go build -o /gcsproxy *.go
-
-FROM alpine:3.18
-RUN apk --no-cache ca-certificates && update-ca-certificates
-CMD ["/gcsproxy"]
-COPY --from=build /gcsproxy /gcsproxy

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,4 +23,18 @@ use_repo(
 )
 
 bazel_dep(name = "rules_oci", version = "2.3.0")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
+
+# Base image for //:image. gcr.io/distroless/static-debian13 ships CA
+# certificates (needed for GCS TLS) and runs as root so the container can bind
+# privileged ports. Digest pinned for reproducibility; refresh with:
+#   crane digest gcr.io/distroless/static-debian13:latest
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci.pull(
+    name = "distroless_static",
+    digest = "sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0",
+    image = "gcr.io/distroless/static-debian13",
+    platforms = ["linux/amd64"],
+)
+use_repo(oci, "distroless_static", "distroless_static_linux_amd64")


### PR DESCRIPTION
## Summary

Build the container image entirely with Bazel (`rules_oci` + `rules_pkg`) instead of the stale `Dockerfile` (which still used `dep`/`Gopkg` and `alpine:3.18`). The image mirrors the upstream contract: entrypoint `/gcsproxy`, default `CMD ["-b", "0.0.0.0:80"]`.

## Changes

- **MODULE.bazel**
  - add `rules_pkg`
  - `oci.pull` of `gcr.io/distroless/static-debian13`, pinned by digest. distroless/static ships CA certificates (needed for GCS TLS) and runs as root so the container can bind privileged port 80.
- **BUILD.bazel**
  - `gcsproxy_linux_amd64` — cross-compiled static binary (`goos=linux`, `goarch=amd64`, `pure = "on"`)
  - `gcsproxy_layer` — `pkg_tar` placing the binary at `/gcsproxy`
  - `//:image` (`oci_image`) and `//:load` (`oci_load` → `gcsproxy:latest`)
- **Delete `Dockerfile`**; document the image targets in `CLAUDE.md`

## Usage

```bash
bazel build //:image     # OCI image (amd64/linux)
bazel run //:load        # load into local Docker as gcsproxy:latest
```

## Test plan

- [x] `bazel build //:image` succeeds
- [x] Layer places the binary at `/gcsproxy` (mode 0755)
- [x] Image config: `architecture=amd64`, `os=linux`, `Entrypoint=["/gcsproxy"]`, `Cmd=["-b","0.0.0.0:80"]`
- [x] Binary is a static x86-64 ELF (`pure` Go, CGO disabled)

## Notes

- Builds on the resync merged in #22.
- Single-arch (linux/amd64) by design, matching the old Dockerfile. Multi-arch (`oci_image_index` over arm64) can be a follow-up if needed.
- `digest` refresh: `crane digest gcr.io/distroless/static-debian13:latest`.