### PR TITLE
chore: bump Go to 1.26.4 and use canonical rules_go repo name

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ There is **no Makefile** and **no Dockerfile**. Tests live in `main_test.go` and
   bazel run //:gazelle    # regenerate go_library / go_test deps
   ```
   Caveat: the `go_library` is named `lib` (not gazelle's default `gcsproxy_lib`), so after gazelle regenerates the `go_test` target, re-point its `embed` from `:gcsproxy_lib` to `:lib`.
-- `go.mod` and `MODULE.bazel` (`go_sdk.download`) both pin the same Go version (`1.25.8`); keep them aligned when bumping.
+- `go.mod` and `MODULE.bazel` (`go_sdk.download`) both pin the same Go version (`1.26.4`); keep them aligned when bumping.
 
 ## Conventions
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,11 +4,11 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "rules_go", version = "0.61.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.61.1")
 bazel_dep(name = "gazelle", version = "0.51.3")
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.25.8")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.26.4")
 go_sdk.host()
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -670,166 +670,162 @@
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
         ]
       },
-      "1.25.8": {
+      "1.26.4": {
         "aix_ppc64": [
-          "go1.25.8.aix-ppc64.tar.gz",
-          "1bf607b624eae2265deb9a7b3d0991598c77e9387207644ddd3538c6722a46b3"
+          "go1.26.4.aix-ppc64.tar.gz",
+          "881bf44c07203fc1759d477412c2dfae425e5d2023acdd79299d5de5b4de8e77"
         ],
         "darwin_amd64": [
-          "go1.25.8.darwin-amd64.tar.gz",
-          "a0b8136598baf192af400051cee2481ffb407f4c113a81ff400896e26cbce9e4"
+          "go1.26.4.darwin-amd64.tar.gz",
+          "05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d"
         ],
         "darwin_arm64": [
-          "go1.25.8.darwin-arm64.tar.gz",
-          "c6547959f5dbe8440bf3da972bd65ba900168de5e7ab01464fbdc7ac8375c21c"
+          "go1.26.4.darwin-arm64.tar.gz",
+          "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53"
         ],
         "dragonfly_amd64": [
-          "go1.25.8.dragonfly-amd64.tar.gz",
-          "861ed963876fd93929fedc2dae706c30b1f23e28daaf028fd71f24ef0b708a81"
+          "go1.26.4.dragonfly-amd64.tar.gz",
+          "bcc3ee1cfb6dd03a2d5abf07174212df1764ae54406c389b71a7fd2d05a8f0c8"
         ],
         "freebsd_386": [
-          "go1.25.8.freebsd-386.tar.gz",
-          "6b28b9c531706fd6cbb8c197b70a31ade42aa3aa537102dcfdcfb516c20852cf"
+          "go1.26.4.freebsd-386.tar.gz",
+          "f4325e0f9a5894e79c60b5e692af55a1e6f261b8ea73dcd20eced8372ad08233"
         ],
         "freebsd_amd64": [
-          "go1.25.8.freebsd-amd64.tar.gz",
-          "660cb8e324633c27bf9a002fa9431b403c74990d124caaf14282db5fb514d183"
+          "go1.26.4.freebsd-amd64.tar.gz",
+          "e91e96c0d3bd8f770e5a0facaf21d010a84e1c9440d830210cb3c223f0b7fb50"
         ],
         "freebsd_arm": [
-          "go1.25.8.freebsd-arm.tar.gz",
-          "f5a4901040f901fbfb909784f58072271a81dbbc5abb5a500e5c0993b8792468"
+          "go1.26.4.freebsd-arm.tar.gz",
+          "36e45b3a843087f0f95a71f2ed453ea7e1727e684644d13f8b4c6c93fd977d41"
         ],
         "freebsd_arm64": [
-          "go1.25.8.freebsd-arm64.tar.gz",
-          "8611b7fc2880a55431f8c59d78312fc49a618ce873ec6f49b7ff182ee4230274"
-        ],
-        "freebsd_riscv64": [
-          "go1.25.8.freebsd-riscv64.tar.gz",
-          "7c260fbef616bd266e01785bfdbd26115174f850a002b0e854f1d3eeaf095296"
+          "go1.26.4.freebsd-arm64.tar.gz",
+          "34aee1071d74cc23703d1b415c5fa44f840d29fd3733dac34944d83cfada3ff3"
         ],
         "illumos_amd64": [
-          "go1.25.8.illumos-amd64.tar.gz",
-          "e962f45b16229081634e626efa7e6c8630ac0e0be5ed7f9c48bfbc349d75805c"
+          "go1.26.4.illumos-amd64.tar.gz",
+          "27603bcd431afab272a5ed81cc951146181e8139640c46ed2ea5b560e1097038"
         ],
         "linux_386": [
-          "go1.25.8.linux-386.tar.gz",
-          "40530cd40ccfa4c9934663c1d6c4ef6fb1651db70ffd50af6687520f51b311bb"
+          "go1.26.4.linux-386.tar.gz",
+          "5ca0982791791559d11a0eba939617a94c3f37c21aa514a55c415b9167efc658"
         ],
         "linux_amd64": [
-          "go1.25.8.linux-amd64.tar.gz",
-          "ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6"
+          "go1.26.4.linux-amd64.tar.gz",
+          "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
         ],
         "linux_arm64": [
-          "go1.25.8.linux-arm64.tar.gz",
-          "7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7"
+          "go1.26.4.linux-arm64.tar.gz",
+          "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
         ],
         "linux_armv6l": [
-          "go1.25.8.linux-armv6l.tar.gz",
-          "cda7e553fa9f6d39e48ed9061bd3da47f6a30b398179d1b2a2f50d9853cafcae"
+          "go1.26.4.linux-armv6l.tar.gz",
+          "8db458e995f18a9427a745cefe7a3323962fa2548c4715148963311f300d3b1a"
         ],
         "linux_loong64": [
-          "go1.25.8.linux-loong64.tar.gz",
-          "0ebadb1805a0d2e15dedba9c702c2e89cb7aa6307415a00d1d1e318112511e8d"
+          "go1.26.4.linux-loong64.tar.gz",
+          "9f6d288d8972dd649ff3ecfdd3ed98e0664b5efb432e841408c054c25af26ed3"
         ],
         "linux_mips": [
-          "go1.25.8.linux-mips.tar.gz",
-          "001fb956e34b3d33a4910be95a20f26a7cc82b6f7deb406d7f6c9af1267e2437"
+          "go1.26.4.linux-mips.tar.gz",
+          "3435d0d8424562dfcf12517040b6a2388ee0f6f20b9d66b2349a6c5034d57997"
         ],
         "linux_mips64": [
-          "go1.25.8.linux-mips64.tar.gz",
-          "054badfc891d688f07fed342a72bf06bb83713d7913fb325857dfaeef8a3f8fb"
+          "go1.26.4.linux-mips64.tar.gz",
+          "691263ab84943aff78d1422dfae66f352d907fc67560e66e7ceec3898fb7d5e6"
         ],
         "linux_mips64le": [
-          "go1.25.8.linux-mips64le.tar.gz",
-          "0feca5fcf234ae6c29d8fd78d4c04d2fe9964eb6be0489cb2090c757e5e0bfea"
+          "go1.26.4.linux-mips64le.tar.gz",
+          "23946b019b118ed85676090fd9110cfa091667c8c52d3d5276b73f3dd46d31f4"
         ],
         "linux_mipsle": [
-          "go1.25.8.linux-mipsle.tar.gz",
-          "0dcc6e2c17a68c805007cd24f6942c09c244aa898616eba498eccd96998d74a7"
+          "go1.26.4.linux-mipsle.tar.gz",
+          "4436df043e2a448f8937d1f944a3cd786d815c872fdce38dd892269845c1c54f"
         ],
         "linux_ppc64": [
-          "go1.25.8.linux-ppc64.tar.gz",
-          "2524fd020455be0fd9708a24d32c150ede3e18d004e244f3ef4e079ae878ba2e"
+          "go1.26.4.linux-ppc64.tar.gz",
+          "d7c3970c1818d63b7b3473a01b9f5f208da1e793a902d3b2e26d5e5174eb6026"
         ],
         "linux_ppc64le": [
-          "go1.25.8.linux-ppc64le.tar.gz",
-          "28ed144a945e4d7188c93f8d85fb772a98ed18f8f9f8d3a650696b739f8cc57c"
+          "go1.26.4.linux-ppc64le.tar.gz",
+          "53f49b8c7eace2d30389327b4a516b13321f90377fdf5929a6b63174609bc22e"
         ],
         "linux_riscv64": [
-          "go1.25.8.linux-riscv64.tar.gz",
-          "1f90bdfabbbf8060f048186f6355b2fb6a839aab499b61f790f90ee5367b05a5"
+          "go1.26.4.linux-riscv64.tar.gz",
+          "2b9ba137baaa3031fd74330cb36ab54c5abe380867ca9fbab7c552f3db740555"
         ],
         "linux_s390x": [
-          "go1.25.8.linux-s390x.tar.gz",
-          "5496dec036f044ba9833db5d1748b6335a679b61f95ac448bdc356a8a7cbcb10"
+          "go1.26.4.linux-s390x.tar.gz",
+          "1e12a2318f3dd4c57027c865f6cb51f5d1e36b02d10f3e6316ce7b61a27b3ca1"
         ],
         "netbsd_386": [
-          "go1.25.8.netbsd-386.tar.gz",
-          "ff1664c484db5a88cabb95489b21542c6c8bb84737e3bbc9a65633656bd22502"
+          "go1.26.4.netbsd-386.tar.gz",
+          "67a172e4780d1b2a5412b73e86798937f2eb2f85aba6d740df4fbe6d6b555fa2"
         ],
         "netbsd_amd64": [
-          "go1.25.8.netbsd-amd64.tar.gz",
-          "182d9b9ee2990879c6af8030aa9f29cec3cced1adeb46b10145c0d3526856092"
+          "go1.26.4.netbsd-amd64.tar.gz",
+          "3321f16e91c7d6d9c8df556690fbe8aef028aac9a0d6d466af9d3c20bd599503"
         ],
         "netbsd_arm": [
-          "go1.25.8.netbsd-arm.tar.gz",
-          "61cc24bf631fc0a3f4136a2f20077891f1025d673faff5b33dc203c8dd323e98"
+          "go1.26.4.netbsd-arm.tar.gz",
+          "a3830f9f0f9fb00648346508d4d2c6fa2d7c1cd4c478fb88051ff6f1b49f0610"
         ],
         "netbsd_arm64": [
-          "go1.25.8.netbsd-arm64.tar.gz",
-          "4b8a6d86f13db657ddee0e4978ad651ec75289b29f024b11b15a5d7d71ea33e1"
+          "go1.26.4.netbsd-arm64.tar.gz",
+          "f240a98583a12f16cd6ea4799d29e5ccdc96892314263c0065e6511c783e26ab"
         ],
         "openbsd_386": [
-          "go1.25.8.openbsd-386.tar.gz",
-          "76568f46851688784c2ac5a71a59bd03b836ffb951f4a271cc03797a56820ed1"
+          "go1.26.4.openbsd-386.tar.gz",
+          "c0c892180ebc9038637f158a010bdc2d962d303d9c0346ae5856fcd2088b16c7"
         ],
         "openbsd_amd64": [
-          "go1.25.8.openbsd-amd64.tar.gz",
-          "dcd515857c70499e1b62ff89401a13d05746d322c4e0833f2a92b9d48a80a73c"
+          "go1.26.4.openbsd-amd64.tar.gz",
+          "cd33f8f7f103cc9151d69795a7f20482335a88cf4eb76a3c56c12afbb5b1b2f0"
         ],
         "openbsd_arm": [
-          "go1.25.8.openbsd-arm.tar.gz",
-          "9fafde8575591f1e4f6052358c0bd5d34a6a361c3b8f977f9742a440b72bb4a7"
+          "go1.26.4.openbsd-arm.tar.gz",
+          "5ab1a54a1dc4f425006101b81c12cd88a457b22496add2bb8b6f6e73b58cf1f1"
         ],
         "openbsd_arm64": [
-          "go1.25.8.openbsd-arm64.tar.gz",
-          "94e9bf0f6774b2af7ccad05a303d502039a80ddce77d9c556fc6cfe14bb3ba64"
+          "go1.26.4.openbsd-arm64.tar.gz",
+          "cf8b0f5d6a043771df53fe70054d2b2b792f4c7693ad6cd5a891c252d813bc33"
         ],
         "openbsd_ppc64": [
-          "go1.25.8.openbsd-ppc64.tar.gz",
-          "5c3b46c2e7201bce2519a74e9d24cf6e1784a18e9984ab6d84e4113b7245400b"
+          "go1.26.4.openbsd-ppc64.tar.gz",
+          "dcf7c6962c43ff67a0d804b989589fe4f3fd574c92b932659c95b1bb32c66f82"
         ],
         "openbsd_riscv64": [
-          "go1.25.8.openbsd-riscv64.tar.gz",
-          "58f93c699435ce0906b6cfe91db478fbe2d55bc6a5a5fa6c36b36138bf1e9e15"
+          "go1.26.4.openbsd-riscv64.tar.gz",
+          "e6ba2daf626770f7d453e7974058dee4b85cb198613ecbb97048a730dc1d5497"
         ],
         "plan9_386": [
-          "go1.25.8.plan9-386.tar.gz",
-          "76b354130e8b1ec5566142dddecd009ad59090b954cc728095ce8d65f5a6ed68"
+          "go1.26.4.plan9-386.tar.gz",
+          "003b912f269786612ad01088178ffcb6f03421fdd61cc4d8b71922571aabd09a"
         ],
         "plan9_amd64": [
-          "go1.25.8.plan9-amd64.tar.gz",
-          "64550745e46e589a8c4d25136fb121f9154331e7d8746d4b75497a554a737fba"
+          "go1.26.4.plan9-amd64.tar.gz",
+          "663871da0f2263d6553828e695be5346f816015f1a6fe7ead22db538ebb6b293"
         ],
         "plan9_arm": [
-          "go1.25.8.plan9-arm.tar.gz",
-          "48e47d686120eb801c5b05bb434830a28b4a2977531e79ad835dcaffd2281047"
+          "go1.26.4.plan9-arm.tar.gz",
+          "9b350fc94bb0c17fe30604e41c7573a9a70bbab258646f0e262a4c6851e4d2b8"
         ],
         "solaris_amd64": [
-          "go1.25.8.solaris-amd64.tar.gz",
-          "08fb8411cca57f619b17ad2dec60dd418c4f2c539f9951a32dd35af9927712a5"
+          "go1.26.4.solaris-amd64.tar.gz",
+          "92eb3f7e224e5dd7ac9e0fb9455f8619c3999faf1e350a9505bb2ed5f7e41b7e"
         ],
         "windows_386": [
-          "go1.25.8.windows-386.zip",
-          "1a48143752863d7a35223f5e1587315e4fa2db7d77695d6ccb11ee5c37b32739"
+          "go1.26.4.windows-386.zip",
+          "2064a4a249fd2ee2db23e7080dc19b42768969f2830541841d0f7a9c80996946"
         ],
         "windows_amd64": [
-          "go1.25.8.windows-amd64.zip",
-          "8d4ed9a270b33df7a6d3ff3a5316e103e0042fcc4f0c9a80e40378700bab6794"
+          "go1.26.4.windows-amd64.zip",
+          "3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345"
         ],
         "windows_arm64": [
-          "go1.25.8.windows-arm64.zip",
-          "0ffaef4a9617a8819294b5f52aefca1415dce644a70f5ad155676293ab052a31"
+          "go1.26.4.windows-arm64.zip",
+          "62247f56fb7d7b827d237152c4e3fcd69a24d0fa9430dc73dbda7593ae82bc8d"
         ]
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kchygoe/gcsproxy
 
-go 1.25.8
+go 1.26.4
 
 require (
 	cloud.google.com/go/auth v0.20.0


### PR DESCRIPTION
## Summary

- Bumps the Go SDK from **1.25.8 → 1.26.4** (current latest stable), keeping `go.mod` and `MODULE.bazel` (`go_sdk.download`) aligned as required by `CLAUDE.md`.
- Drops the legacy `io_bazel_rules_go` repo alias and references `rules_go` by its canonical module name in both `MODULE.bazel` and `BUILD.bazel`.
- Regenerates `MODULE.bazel.lock` and updates the pinned-version note in `CLAUDE.md`.

## Test plan

- [x] `go build -o /dev/null .`
- [x] `go test -race ./...`
- [x] `bazel build //:gcsproxy`
- [x] `bazel test //:gcsproxy_test`
- [x] `bazel build //:image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)